### PR TITLE
Java 1.8 instead of 1.7

### DIFF
--- a/datanode/Dockerfile
+++ b/datanode/Dockerfile
@@ -24,13 +24,13 @@ COPY ssh_config /root/.ssh/config
 RUN chmod 600 /root/.ssh/config && chown root:root /root/.ssh/config
 
 # java
-RUN curl -LO 'http://download.oracle.com/otn-pub/java/jdk/7u71-b14/jdk-7u71-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && \
-	rpm -i jdk-7u71-linux-x64.rpm && \
-	rm jdk-7u71-linux-x64.rpm
+RUN curl -LO 'http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && \
+	rpm -i jdk-8u131-linux-x64.rpm && \
+	rm jdk-8u131-linux-x64.rpm
 
 ENV JAVA_HOME /usr/java/default
 
-RUN curl -s http://www.us.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz | tar -xz -C /usr/local/ && \
+RUN curl -LO 'https://archive.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz' && chmod 700 hadoop-2.7.1.tar.gz && tar -xvzf hadoop-2.7.1.tar.gz -C /usr/local/ && \
 	cd /usr/local && \
 	ln -s ./hadoop-2.7.1 hadoop
 

--- a/datanode/yarn-site.xml.template
+++ b/datanode/yarn-site.xml.template
@@ -28,13 +28,22 @@
 		<name>yarn.resourcemanager.webapp.address</name>
 		<value>HOSTNAME:8088</value>
 	</property>
-
 	
 	<property>
 		<name>yarn.nodemanager.aux-services</name>
 		<value>mapreduce_shuffle</value>
 	</property>
-  
+
+  <property>
+      <name>yarn.nodemanager.pmem-check-enabled</name>
+      <value>false</value>
+  </property>
+
+  <property>
+      <name>yarn.nodemanager.vmem-check-enabled</name>
+      <value>false</value>
+  </property>
+
 	<property>
 		<name>yarn.scheduler.minimum-allocation-mb</name>
 		<value>128</value>

--- a/namenode/Dockerfile
+++ b/namenode/Dockerfile
@@ -25,12 +25,13 @@ COPY ssh_config /root/.ssh/config
 RUN chmod 600 /root/.ssh/config && chown root:root /root/.ssh/config
 
 # java
-RUN curl -LO 'http://download.oracle.com/otn-pub/java/jdk/7u71-b14/jdk-7u71-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && rpm -i jdk-7u71-linux-x64.rpm && rm jdk-7u71-linux-x64.rpm
+RUN curl -LO 'http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && rpm -i jdk-8u131-linux-x64.rpm && rm jdk-8u131-linux-x64.rpm
 
 ENV JAVA_HOME /usr/java/default
 
-RUN curl -s http://www.us.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz | tar -xz -C /usr/local/
-RUN cd /usr/local && ln -s ./hadoop-2.7.1 hadoop
+RUN curl -LO 'https://archive.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz' && chmod 700 hadoop-2.7.1.tar.gz && tar -xvzf hadoop-2.7.1.tar.gz -C /usr/local/ && \
+	cd /usr/local && \
+	ln -s ./hadoop-2.7.1 hadoop
 
 ENV HADOOP_PREFIX /usr/local/hadoop
 ENV HADOOP_COMMON_HOME /usr/local/hadoop

--- a/yarn/Dockerfile
+++ b/yarn/Dockerfile
@@ -21,15 +21,16 @@ COPY ssh_config /root/.ssh/config
 RUN chmod 600 /root/.ssh/config && chown root:root /root/.ssh/config
 
 # java
-RUN curl -LO 'http://download.oracle.com/otn-pub/java/jdk/7u71-b14/jdk-7u71-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && \
-    rpm -i jdk-7u71-linux-x64.rpm && \
-    rm jdk-7u71-linux-x64.rpm
+RUN curl -LO 'http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.rpm' -H 'Cookie: oraclelicense=accept-securebackup-cookie' && \
+    rpm -i jdk-8u131-linux-x64.rpm && \
+    rm jdk-8u131-linux-x64.rpm
 
 ENV JAVA_HOME /usr/java/default
 ENV PATH $PATH:$JAVA_HOME/bin:$HADOOP_PREFIX/bin
 
-RUN curl -s http://www.us.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz | tar -xz -C /usr/local/
-RUN cd /usr/local && ln -s ./hadoop-2.7.1 hadoop
+RUN curl -LO 'https://archive.apache.org/dist/hadoop/common/hadoop-2.7.1/hadoop-2.7.1.tar.gz' && chmod 700 hadoop-2.7.1.tar.gz && tar -xvzf hadoop-2.7.1.tar.gz -C /usr/local/ && \
+	cd /usr/local && \
+	ln -s ./hadoop-2.7.1 hadoop
 
 ENV HADOOP_PREFIX /usr/local/hadoop
 ENV HADOOP_COMMON_HOME /usr/local/hadoop

--- a/yarn/yarn-site.xml.template
+++ b/yarn/yarn-site.xml.template
@@ -35,6 +35,16 @@
 	</property>
 
 	<property>
+        <name>yarn.nodemanager.pmem-check-enabled</name>
+        <value>false</value>
+    </property>
+
+    <property>
+        <name>yarn.nodemanager.vmem-check-enabled</name>
+        <value>false</value>
+    </property>
+
+	<property>
 		<name>yarn.scheduler.minimum-allocation-mb</name>
 		<value>128</value>
 		<description>Minimum limit of memory to allocate to each container request at the Resource Manager.</description>


### PR DESCRIPTION
Initially the reason for this PR was `com.typesafe.config` library v.1.3.0, which required the usage of JDK 1.8, but i thought it may be useful for other purposes as well.

Regarding changes in `yarn-site.xml` templates: https://issues.apache.org/jira/browse/YARN-4714 causes containers to die before any execution can start. So, an ugly (but still easy) workaround is disabling node manager's `yarn.nodemanager.vmem-check-enabled` and `yarn.nodemanager.pmem-check-enabled`.